### PR TITLE
fix: add fallback for hm-options in default profile

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
       defaultPackage = self.packages.${system}.manix;
       packages.manix = naersk'.buildPackage {
         src = ./.;
+        name = "manix";
       };
 
       # For `nix develop` (optional, can be skipped):

--- a/src/bin/manix.rs
+++ b/src/bin/manix.rs
@@ -231,7 +231,12 @@ fn main() -> Result<()> {
         )
         .is_none()
         {
-            eprintln!("Tip: If you installed your home-manager through configuration.nix you can fix this error by adding the home-manager channel with this command: {}", "nix-channel --add https://github.com/rycee/home-manager/archive/master.tar.gz home-manager && nix-channel --update".bold());
+            eprintln!(
+                "Tip: If you installed your home-manager through configuration.nix you can fix this error \
+                by adding the home-manager channel with this command: {}\n\
+                Otherwise, make sure you have `manual.json.enable` set in your home configuration",
+                "nix-channel --add https://github.com/rycee/home-manager/archive/master.tar.gz home-manager && nix-channel --update".bold(),
+            );
         }
 
         if build_source_and_add(

--- a/src/nix/hm-options.nix
+++ b/src/nix/hm-options.nix
@@ -1,5 +1,5 @@
 {
-  release ? "23.05",
+  release ? "24.05",
   isReleaseBranch ? false,
   pkgs ? import <nixpkgs> {},
 }: let


### PR DESCRIPTION
If user didn't set up home-manager through channels, add an option to look for it in default nix profile before failing.

fixes #18 