### PR TITLE
docs: faster and preview-only fzf examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ If you want to use it in your editor, check [ElKowar's rnix-lsp fork](https://gi
 ### fzf
 
 ```sh
-manix "" | grep '^# ' | sed 's/^# \(.*\) (.*/\1/;s/ (.*//;s/^# //' | fzf --preview="manix '{}'" | xargs manix
+manix "" | sed -n 's/^# \(.*\) \?.*/\1/p' | fzf --preview="manix '{}'" | xargs manix
+```
+
+Or, alternatively, without the final output if preview is enough:
+
+```sh
+manix "" | sed -n 's/^# \(.*\) \?.*/\1/p' | fzf --preview="manix '{}'"
 ```
 
 ## Installation


### PR DESCRIPTION
- using `sed` alone and with simpler regex makes the oneliner noticeably faster

- no-preview example: for me preview is usually enough; this also "fixes" the annoying behavior when if fzf is terminated by `c-C`, manix shows an error

