### PR TITLE
Add JSON Output Option

### DIFF
--- a/src/bin/manix.rs
+++ b/src/bin/manix.rs
@@ -10,7 +10,10 @@ use options_docsource::{
     OptionsDatabase,
     OptionsDatabaseType,
 };
-use std::{path::PathBuf, io};
+use std::{
+    io::{self, Write},
+    path::PathBuf,
+};
 use clap::{Parser, ValueEnum, ValueHint, Command, CommandFactory};
 use lazy_static::lazy_static;
 use clap_complete::{generate, Generator, Shell};
@@ -136,56 +139,60 @@ where
     }
 }
 
-fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
-        generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
+fn print_completions<G: Generator, W: Write>(gen: G, cmd: &mut Command, writer: &mut W) {
+    generate(gen, cmd, cmd.get_name().to_string(), writer);
 }
 
-fn print_human_output(results: &SearchResults) {
+fn print_human_output<W: Write>(results: &SearchResults, writer: &mut W) -> Result<()> {
     if !results.key_only_entries.is_empty() {
         const SHOW_MAX_LEN: usize = 50;
-        print!("{}", "Here's what I found in nixpkgs:".bold());
+        write!(writer, "{}", "Here's what I found in nixpkgs:".bold())?;
         for entry in results.key_only_entries.iter().take(SHOW_MAX_LEN) {
-            print!(" {}", entry.name().white());
+            write!(writer, " {}", entry.name().white())?;
         }
         if results.key_only_entries.len() > SHOW_MAX_LEN {
-            print!(" and {} more.", results.key_only_entries.len() - SHOW_MAX_LEN);
+            write!(writer, " and {} more.", results.key_only_entries.len() - SHOW_MAX_LEN)?;
         }
-        println!("\n");
+        writeln!(writer, "\n")?;
     }
 
     for entry in &results.entries {
         const LINE: &str = "────────────────────";
-        println!(
+        writeln!(
+            writer,
             "{}\n{}\n{}",
             entry.source().white(),
             LINE.green(),
             entry.pretty_printed()
-        );
+        )?;
     }
+
+    Ok(())
 }
 
-fn print_json_output(results: &SearchResults) -> Result<()> {
-    println!(
-        "{}",
-        serde_json::to_string(results).context("Failed to serialize search results as JSON")?
-    );
+fn print_json_output<W: Write>(results: &SearchResults, writer: &mut W) -> Result<()> {
+    serde_json::to_writer(&mut *writer, results)
+        .context("Failed to serialize search results as JSON")?;
+    writeln!(writer)?;
     Ok(())
 }
 
 fn main() -> Result<()> {
     let opt: Opt = Opt::parse();
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
 
     if let Some(generator) = opt.generator {
         let mut cmd = Opt::command();
         eprintln!("Generating completion file for {generator:?}...");
 
 	    match generator {
-	    	ShellCompletion::Bash => print_completions(Shell::Bash, &mut cmd),
-	    	ShellCompletion::Elvish => print_completions(Shell::Elvish, &mut cmd),
-	    	ShellCompletion::Fish => print_completions(Shell::Fish , &mut cmd),
-	    	ShellCompletion::Nu => print_completions(clap_complete_nushell::Nushell , &mut cmd),
-	    	ShellCompletion::Powershell => print_completions(Shell::PowerShell, &mut cmd),
-	    	ShellCompletion::Zsh => print_completions(Shell::Zsh , &mut cmd)
+	    	ShellCompletion::Bash => print_completions(Shell::Bash, &mut cmd, &mut stdout),
+	    	ShellCompletion::Elvish => print_completions(Shell::Elvish, &mut cmd, &mut stdout),
+	    	ShellCompletion::Fish => print_completions(Shell::Fish , &mut cmd, &mut stdout),
+	    	ShellCompletion::Nu => print_completions(clap_complete_nushell::Nushell , &mut cmd, &mut stdout),
+	    	ShellCompletion::Powershell => print_completions(Shell::PowerShell, &mut cmd, &mut stdout),
+	    	ShellCompletion::Zsh => print_completions(Shell::Zsh , &mut cmd, &mut stdout)
 	    }
 
         Ok(())
@@ -195,7 +202,9 @@ fn main() -> Result<()> {
         let cmd = Opt::command();
         eprintln!("Generating manpage...");
         
-        Man::new(cmd).render(&mut io::stdout()).unwrap();
+        Man::new(cmd)
+            .render(&mut stdout)
+            .context("Failed to render manpage")?;
 
         Ok(())
     } else {
@@ -378,9 +387,9 @@ fn main() -> Result<()> {
     let results = SearchResults::from_entries(entries);
 
     if opt.json {
-        print_json_output(&results)?;
+        print_json_output(&results, &mut stdout)?;
     } else {
-        print_human_output(&results);
+        print_human_output(&results, &mut stdout)?;
     }
 
     Ok(())

--- a/src/bin/manix.rs
+++ b/src/bin/manix.rs
@@ -13,7 +13,7 @@ use options_docsource::{
 use std::{path::PathBuf, io};
 use clap::{Parser, ValueEnum, ValueHint, Command, CommandFactory};
 use lazy_static::lazy_static;
-use clap_complete::{generate, Generator, Shell, generator};
+use clap_complete::{generate, Generator, Shell};
 use clap_mangen::Man;
 
 #[derive(Debug, PartialEq, Clone, ValueEnum, VariantNames)]
@@ -60,6 +60,10 @@ struct Opt {
     /// Query to search for
     #[arg(name = "QUERY", value_hint = ValueHint::CommandString)]
     query: String,
+
+    /// Output results as JSON
+    #[arg(short, long)]
+    json: bool,
     
     /// Generate completions for the specified shell
     #[arg(long = "generate", value_enum)]
@@ -134,6 +138,38 @@ where
 
 fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
         generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
+}
+
+fn print_human_output(results: &SearchResults) {
+    if !results.key_only_entries.is_empty() {
+        const SHOW_MAX_LEN: usize = 50;
+        print!("{}", "Here's what I found in nixpkgs:".bold());
+        for entry in results.key_only_entries.iter().take(SHOW_MAX_LEN) {
+            print!(" {}", entry.name().white());
+        }
+        if results.key_only_entries.len() > SHOW_MAX_LEN {
+            print!(" and {} more.", results.key_only_entries.len() - SHOW_MAX_LEN);
+        }
+        println!("\n");
+    }
+
+    for entry in &results.entries {
+        const LINE: &str = "────────────────────";
+        println!(
+            "{}\n{}\n{}",
+            entry.source().white(),
+            LINE.green(),
+            entry.pretty_printed()
+        );
+    }
+}
+
+fn print_json_output(results: &SearchResults) -> Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string(results).context("Failed to serialize search results as JSON")?
+    );
+    Ok(())
 }
 
 fn main() -> Result<()> {
@@ -339,30 +375,12 @@ fn main() -> Result<()> {
     } else {
         aggregate_source.search_liberal(&query)
     };
-    let (entries, key_only_entries): (Vec<DocEntry>, Vec<DocEntry>) = entries
-        .into_iter()
-        .partition(|e| !matches!(e, DocEntry::NixpkgsTreeDoc(_)));
+    let results = SearchResults::from_entries(entries);
 
-    if !key_only_entries.is_empty() {
-        const SHOW_MAX_LEN: usize = 50;
-        print!("{}", "Here's what I found in nixpkgs:".bold());
-        for entry in key_only_entries.iter().take(SHOW_MAX_LEN) {
-            print!(" {}", entry.name().white());
-        }
-        if key_only_entries.len() > SHOW_MAX_LEN {
-            print!(" and {} more.", key_only_entries.len() - SHOW_MAX_LEN);
-        }
-        println!("\n");
-    }
-
-    for entry in entries {
-        const LINE: &str = "────────────────────";
-        println!(
-            "{}\n{}\n{}",
-            entry.source().white(),
-            LINE.green(),
-            entry.pretty_printed()
-        );
+    if opt.json {
+        print_json_output(&results)?;
+    } else {
+        print_human_output(&results);
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use rayon::iter::{
     IntoParallelRefIterator,
     ParallelIterator,
 };
+use serde::ser::SerializeStruct;
 use std::path::PathBuf;
 use thiserror::Error;
 use xml_docsource::XmlFuncDocumentation;
@@ -55,6 +56,25 @@ pub enum Errors {
     },
 }
 
+#[derive(Debug, serde::Serialize)]
+pub struct SearchResults {
+    pub entries: Vec<DocEntry>,
+    pub key_only_entries: Vec<DocEntry>,
+}
+
+impl SearchResults {
+    pub fn from_entries(entries: Vec<DocEntry>) -> Self {
+        let (entries, key_only_entries) = entries
+            .into_iter()
+            .partition(|entry| !matches!(entry, DocEntry::NixpkgsTreeDoc(_)));
+
+        Self {
+            entries,
+            key_only_entries,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum DocEntry {
     OptionDoc(OptionsDatabaseType, OptionDocumentation),
@@ -64,6 +84,15 @@ pub enum DocEntry {
 }
 
 impl DocEntry {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            DocEntry::OptionDoc(_, _) => "option",
+            DocEntry::CommentDoc(_) => "comment",
+            DocEntry::XmlFuncDoc(_) => "xml_function",
+            DocEntry::NixpkgsTreeDoc(_) => "nixpkgs_tree",
+        }
+    }
+
     pub fn name(&self) -> String {
         match self {
             DocEntry::OptionDoc(_, x) => x.name(),
@@ -91,6 +120,33 @@ impl DocEntry {
             DocEntry::XmlFuncDoc(_) => "Nixpkgs Documentation",
             DocEntry::NixpkgsTreeDoc(_) => "Nixpkgs Tree",
         }
+    }
+}
+
+impl serde::Serialize for DocEntry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("DocEntry", 4)?;
+        state.serialize_field("kind", self.kind())?;
+        state.serialize_field("source", self.source())?;
+        state.serialize_field("name", &self.name())?;
+        match self {
+            DocEntry::OptionDoc(_, documentation) => {
+                state.serialize_field("documentation", documentation)?;
+            }
+            DocEntry::CommentDoc(documentation) => {
+                state.serialize_field("documentation", documentation)?;
+            }
+            DocEntry::XmlFuncDoc(documentation) => {
+                state.serialize_field("documentation", documentation)?;
+            }
+            DocEntry::NixpkgsTreeDoc(_) => {
+                state.serialize_field("documentation", &Option::<()>::None)?;
+            }
+        }
+        state.end()
     }
 }
 

--- a/src/options_docsource.rs
+++ b/src/options_docsource.rs
@@ -148,7 +148,5 @@ pub fn get_nd_json_doc_path() -> Result<PathBuf, std::io::Error> {
         .output()
         .map(|o| String::from_utf8(o.stdout).unwrap())?;
 
-    println!("{}", base_path_output.trim_end_matches('\n'));
-
     Ok(PathBuf::from(base_path_output.trim_end_matches('\n')))
 }


### PR DESCRIPTION
`manix` is excellent for human use, but it can be difficult to parse the output programmatically.

This PR adds a `-j/--json` flag that instructs `manix` to output a singular JSON object instead of printing in a human-readable structure.

Additionally, it refactors a bit to have all terminal output/input work with `std::io` devices explicitly. This allows direct serialization to stdout.
> This part is not required for the JSON functionality. I find it to be a better design, but if we would rather not do these explicitly, this part can be removed.